### PR TITLE
Adjust max width breakpoint of menu.scss

### DIFF
--- a/components/_menu.scss
+++ b/components/_menu.scss
@@ -1,5 +1,5 @@
 /* NavBar */
-@media (max-width: 960px) {
+@media (max-width: 959px) {
   .menu-wrap {
     .ham {
       position: absolute;

--- a/css/styles.css
+++ b/css/styles.css
@@ -130,7 +130,7 @@ li {
 }
 
 /* NavBar */
-@media (max-width: 960px) {
+@media (max-width: 959px) {
   .menu-wrap {
     /* change ham image to close */
   }


### PR DESCRIPTION
**Added Changes**
- Added max width breakpoint to fix hamburger menu on devices from 959px and below.